### PR TITLE
Release 0.2.2 -- temporarily disable 'check' blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,28 +27,29 @@ locals {
 }
 
 # Validation resource to check if cold storage is enabled for unsupported resources
-check "cold_storage_validation" {
-  assert {
-    condition = (
-      !var.enable_cold_storage_check ||
-      var.cold_storage_after == null ||
-      length(local.cold_storage_unsupported_resources) == 0
-    )
-    error_message = (
-      var.enable_cold_storage_check &&
-      var.cold_storage_after != null &&
-      length(local.cold_storage_unsupported_resources) > 0
-    ) ? "Error: Cold storage is enabled and configured, but the following resources do not support it: ${join(", ", local.cold_storage_unsupported_resources)}. Please review your configuration." : "Cold storage configuration is valid."
-  }
-}
+# check "cold_storage_validation" {
+#   assert {
+#     condition = (
+#       !var.enable_cold_storage_check ||
+#       var.cold_storage_after == null ||
+#       length(local.cold_storage_unsupported_resources) == 0
+#     )
+#     error_message = (
+#       var.enable_cold_storage_check &&
+#       var.cold_storage_after != null &&
+#       length(local.cold_storage_unsupported_resources) > 0
+#     ) ? "Error: Cold storage is enabled and configured, but the following resources do not support it: ${join(", ", local.cold_storage_unsupported_resources)}. Please review your configuration." : "Cold storage configuration is valid."
+#   }
+# }
 
 # Validation to ensure delete_after is at least 90 days more than cold_storage_after
-check "lifecycle_validation" {
-  assert {
-    condition     = var.cold_storage_after == null || var.delete_after == null || (var.delete_after - var.cold_storage_after) >= 90
-    error_message = "Error: delete_after must be at least 90 days more than cold_storage_after"
-  }
-}
+# check "lifecycle_validation" {
+#   assert {
+#     condition     = var.cold_storage_after == null || var.delete_after == null || (var.delete_after - var.cold_storage_after) >= 90
+#     error_message = "Error: delete_after must be at least 90 days more than cold_storage_after"
+#   }
+# }
+
 # Encryption key for the Backup Vault
 resource "aws_kms_key" "bkup_key" {
   description = "${var.app_name}-${var.app_env} backup vault key"


### PR DESCRIPTION

### Removed
- Removed the check blocks because they require Terraform version 1.5. Will re-add them when we are ready to do a major version bump on repositories that use this.
