### PR TITLE
Release 0.3.1 -- fix bug in validation check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,12 +31,12 @@ check "cold_storage_validation" {
   assert {
     condition = (
       !var.enable_cold_storage_check ||
-      var.cold_storage_after == null ||
+      var.cold_storage_after == 0 ||
       length(local.cold_storage_unsupported_resources) == 0
     )
     error_message = (
       var.enable_cold_storage_check &&
-      var.cold_storage_after != null &&
+      var.cold_storage_after != 0 &&
       length(local.cold_storage_unsupported_resources) > 0
     ) ? "Error: Cold storage is enabled and configured, but the following resources do not support it: ${join(", ", local.cold_storage_unsupported_resources)}. Please review your configuration." : "Cold storage configuration is valid."
   }
@@ -45,7 +45,7 @@ check "cold_storage_validation" {
 # Validation to ensure delete_after is at least 90 days more than cold_storage_after
 check "lifecycle_validation" {
   assert {
-    condition     = var.cold_storage_after == null || var.delete_after == null || (var.delete_after - var.cold_storage_after) >= 90
+    condition     = var.cold_storage_after == 0 || (var.delete_after - var.cold_storage_after) >= 90
     error_message = "Error: delete_after must be at least 90 days more than cold_storage_after"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,6 @@ locals {
     for arn in var.source_arns : arn
     if !contains(local.supported_resource_types, split(":", arn)[2])
   ] : []
-
-  # Error message for resources that don't support cold storage
-  cold_storage_error_message = (
-    var.enable_cold_storage_check &&
-    var.cold_storage_after != null &&
-    length(local.cold_storage_unsupported_resources) > 0
-  ) ? "Error: cold storage is not supported for the following resources: ${join(", ", local.cold_storage_unsupported_resources)}." : null
 }
 
 # Validation resource to check if cold storage is enabled for unsupported resources

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "sns_email_subscription" {
 }
 
 variable "cold_storage_after" {
-  description = "Number of days after which the backup is moved to cold storage"
+  description = "Number of days after which the backup is moved to cold storage. Set to 0 (zero) to disable."
   type        = number
   default     = 7
 }


### PR DESCRIPTION

### Removed
- Removed unused local `cold_storage_error_message`.

### Fixed
- Fixed a bug in the validation check for cold storage. Since all Terraform expressions must evaluate without error, null is not a valid option for `cold_storage_after` or `delete_after`.