### PR TITLE
add support for AWS provider v6

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,38 +1,13 @@
-# This workflow installs the latest version of Terraform CLI. On pull request events, this workflow will run
-# `terraform init`, `terraform fmt`, and `terraform plan`.
-#
-# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
-
-name: 'Terraform'
+name: Terraform
 
 on:
   push:
-    branches: ["**"]
+    branches: [ '**' ]
 
 jobs:
-  terraform:
-    name: 'Terraform'
-    runs-on: ubuntu-latest
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v6
-
-    # Install the latest version of Terraform CLI
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v4
-      with:
-        terraform_version: "<1.6.0" # only use open source version of Terraform
-
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      run: terraform fmt -check -diff -recursive
-
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      run: terraform -chdir=test init
-
-    # Validate the files, referring only to the configuration and not accessing any remote services
-    - name: Terraform Validate
-      run: terraform -chdir=test validate
+  build:
+    uses: sil-org/workflows/.github/workflows/terraform.yml@main
+    with:
+      # validate with the earliest minor version allowed by required_version in versions.tf
+      terraform-version: '~> 1.5.0'
+      test-dir: 'test'

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,7 @@ variable "source_arns" {
 
 variable "backup_schedule" {
   description = "Backup schedule in AWS Cloudwatch Event Bridge format, e.g.\"cron(11 1 * * ? *)\""
+  type        = string
   default     = "cron(11 1 * * ? *)" # Every day at 01:11 UTC
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0, < 6.0.0"
+      version = ">= 4.0.0, < 7.0.0"
     }
   }
 }


### PR DESCRIPTION
[ITSE-2706](https://support.gtis.sil.org/issue/ITSE-2706) Update Terraform AWS provider to 6.x

### Added
- support for AWS provider v6

